### PR TITLE
Github http URLs can contain username

### DIFF
--- a/magithub.el
+++ b/magithub.el
@@ -141,7 +141,7 @@ repo, and SSH is non-nil if it's checked out via SSH."
   (block nil
     (let ((url (magit-get "remote" remote "url")))
       (unless url (return))
-      (when (string-match "\\(?:git\\|https?\\)://github\\.com/\\(.*?\\)/\\(.*\\)\.git" url)
+      (when (string-match "\\(?:git\\|https?\\)://.*@?github\\.com/\\(.*?\\)/\\(.*\\)\.git" url)
         (return (list (match-string 1 url) (match-string 2 url) nil)))
       (when (string-match "git@github\\.com:\\(.*?\\)/\\(.*\\)\\.git" url)
         (return (list (match-string 1 url) (match-string 2 url) t)))


### PR DESCRIPTION
Update url pattern for github urls to accept http urls with usernames, 
e.g. http://user@github.com/organization/some-project.git
