### PR TITLE
Remove dependence on void magit variable

### DIFF
--- a/magithub.el
+++ b/magithub.el
@@ -43,7 +43,7 @@ This is more secure, but slower."
   :group 'magithub
   :type 'hook)
 
-(defcustom magithub-message-confirm-cancellation magit-log-edit-confirm-cancellation
+(defcustom magithub-message-confirm-cancellation t
   "If non-nil, confirm when cancelling the editing of a `magithub-message-mode' buffer."
   :group 'magithub
   :type 'boolean)


### PR DESCRIPTION
The variable magit-log-edit-confirm-cancellation appears to be removed from magit, causing magithub to crash the initialization of magit.

This commit fixes #11
